### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,19 +10,19 @@ CFLAGS = -I$(CURDIR)/Include -Og -g -std=c11
 
 LDFLAGS = -L$(CURDIR)/Libraries -lm -lGL -lSDL2 -lGLU
 
-.PHONY: all clean
+.PHONY: all clean objs copy_resources
 
-all: ./bin $(OBJS) ./bin/MinecraftC
+all: ./bin ./bin/MinecraftC 
 
 %.o: %.c
 	cd bin/obj; $(CC) $(CFLAGS) -c ../../$^
 
-./bin/MinecraftC:
+./bin/MinecraftC: $(OBJS)
 	$(CC) $(LDFLAGS) -o $@ ./bin/obj/*.o
+	cp -vr Resources/* bin/
 
 ./bin:
 	mkdir -p bin/obj
 
-clean: 
-	rm -rf bin/obj
-	rm -f bin/MinecraftC
+clean:
+	rm -rf bin

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+rwildcard=$(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst *,%,$2),$d))
+
+SRC = $(call rwildcard,MinecraftC/,*.c *.h)
+OBJS = $(patsubst %.c, %.o, $(SRC))
+
+# since we use clang-specific extensions, this should not be changed
+CC := clang
+# flags -Og -g are currently here for debug, replace with -O2 or -O3 for release
+CFLAGS = -I$(CURDIR)/Include -Og -g -std=c11
+
+LDFLAGS = -L$(CURDIR)/Libraries -lm -lGL -lSDL2 -lGLU
+
+.PHONY: all clean
+
+all: ./bin $(OBJS) ./bin/MinecraftC
+
+%.o: %.c
+	cd bin/obj; $(CC) $(CFLAGS) -c ../../$^
+
+./bin/MinecraftC:
+	$(CC) $(LDFLAGS) -o $@ ./bin/obj/*.o
+
+./bin:
+	mkdir -p bin/obj
+
+clean: 
+	rm -rf bin/obj
+	rm -f bin/MinecraftC

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CC := clang
 # flags -Og -g are currently here for debug, replace with -O2 or -O3 for release
 CFLAGS = -I$(CURDIR)/Include -Og -g -std=c11
 
-LDFLAGS = -L$(CURDIR)/Libraries -lm -lGL -lSDL2 -lGLU
+LDFLAGS = -L$(CURDIR)/Libraries -flto -lm -lGL -lSDL2 -lGLU
 
 .PHONY: all clean objs copy_resources
 


### PR DESCRIPTION
Adds a Makefile, only links properly for linux library names at this point.

To build, run

```sh
make all
```

or

```sh
make -j T all
```

where `T` is how many threads you want it to use, so for example, for 8 threads:

```sh
make -j 8 all
```

It produces a directory `./bin`, and there you find the MinecraftC executable. It only builds one, but you can easily change it to build one for creative, one for survival, but I wasn't sure which files to use there. It also copies the resources into the bin folder.

To run the game, `cd` into the `bin` directory and execute `./MinecraftC`.

`make clean` will delete all files produced by `make`.