### PR TITLE
add missing stdlib header files

### DIFF
--- a/MinecraftC/GUI/LoadLevelScreen.c
+++ b/MinecraftC/GUI/LoadLevelScreen.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include "LoadLevelScreen.h"
 #include "SaveLevelScreen.h"
 #include "../Minecraft.h"

--- a/MinecraftC/GameSettings.c
+++ b/MinecraftC/GameSettings.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include "GameSettings.h"
 #include "Minecraft.h"
 #include "KeyBinding.h"

--- a/MinecraftC/Minecraft.c
+++ b/MinecraftC/Minecraft.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include <OpenGL.h>
 #include "Minecraft.h"
 #include "GameMode/CreativeMode.h"

--- a/MinecraftC/Render/TextureManager.c
+++ b/MinecraftC/Render/TextureManager.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include <OpenGL.h>
 #include <stb_image.h>
 #include "TextureManager.h"


### PR DESCRIPTION
Some string functions are being used without inclusion of string.h which might result in a compiler warning or error.