### PR TITLE
Fix compilation errors when compiling with -pedantic-errors on clang

### DIFF
--- a/MinecraftC/Entity.c
+++ b/MinecraftC/Entity.c
@@ -40,7 +40,7 @@ Entity EntityCreate(Level level)
 
 void EntityResetPosition(Entity entity)
 {
-	if (entity->Type == EntityTypeMob && ((MobData)entity->TypeData)->Type == MobTypePlayer) { return PlayerResetPosition(entity); }
+	if (entity->Type == EntityTypeMob && ((MobData)entity->TypeData)->Type == MobTypePlayer) { PlayerResetPosition(entity); return; }
 	if (entity->Level != NULL)
 	{
 		float2 spawn = { entity->Level->Spawn.x + 0.5, entity->Level->Spawn.y };
@@ -65,7 +65,7 @@ void EntityResetPosition(Entity entity)
 
 void EntityRemove(Entity entity)
 {
-	if (entity->Type == EntityTypeMob && ((MobData)entity->TypeData)->Type == MobTypePlayer) { return PlayerRemove(entity); }
+	if (entity->Type == EntityTypeMob && ((MobData)entity->TypeData)->Type == MobTypePlayer) { PlayerRemove(entity); return; }
 	entity->Removed = true;
 }
 
@@ -99,17 +99,17 @@ void EntityInterpolateTurn(Entity entity, float2 angle)
 
 void EntityTick(Entity entity)
 {
-	if (entity->Type == EntityTypeItem) { return ItemTick(entity); }
-	if (entity->Type == EntityTypeTakeAnimation) { return TakeAnimationTick(entity); }
-	if (entity->Type == EntityTypePrimedTNT) { return PrimedTNTTick(entity); }
-	if (entity->Type == EntityTypeArrow) { return ArrowTick(entity); }
-	if (entity->Type == EntityTypeParticle) { return ParticleTick(entity); }
+	if (entity->Type == EntityTypeItem) { ItemTick(entity); return; }
+	if (entity->Type == EntityTypeTakeAnimation) { TakeAnimationTick(entity); return; }
+	if (entity->Type == EntityTypePrimedTNT) { PrimedTNTTick(entity); return; }
+	if (entity->Type == EntityTypeArrow) { ArrowTick(entity); return; }
+	if (entity->Type == EntityTypeParticle) { ParticleTick(entity); return; }
 	
 	entity->OldWalkDistance = entity->WalkDistance;
 	entity->OldPosition = entity->Position;
 	entity->OldRotation = entity->Rotation;
 	
-	if (entity->Type == EntityTypeMob) { return MobTick(entity); }
+	if (entity->Type == EntityTypeMob) { MobTick(entity); return; }
 }
 
 bool EntityIsFree(Entity entity, float3 a)
@@ -294,11 +294,11 @@ float EntityGetBrightness(Entity entity, float t)
 
 void EntityRender(Entity entity, TextureManager textures, float t)
 {
-	if (entity->Type == EntityTypeItem) { return ItemRender(entity, textures, t); }
-	if (entity->Type == EntityTypeTakeAnimation) { return TakeAnimationRender(entity, textures, t); }
-	if (entity->Type == EntityTypePrimedTNT) { return PrimedTNTRender(entity, textures, t); }
-	if (entity->Type == EntityTypeArrow) { return ArrowRender(entity, textures, t); }
-	if (entity->Type == EntityTypeMob) { return MobRender(entity, textures, t); }
+	if (entity->Type == EntityTypeItem) { ItemRender(entity, textures, t); return; }
+	if (entity->Type == EntityTypeTakeAnimation) { TakeAnimationRender(entity, textures, t); return; }
+	if (entity->Type == EntityTypePrimedTNT) { PrimedTNTRender(entity, textures, t); return; }
+	if (entity->Type == EntityTypeArrow) { ArrowRender(entity, textures, t); return; }
+	if (entity->Type == EntityTypeMob) { MobRender(entity, textures, t); return; }
 }
 
 void EntitySetLevel(Entity entity, Level level)
@@ -336,9 +336,9 @@ float EntitySquaredDistanceTo(Entity entityA, Entity entityB)
 
 void EntityPlayerTouch(Entity entity, Entity player)
 {
-	if (entity->Type == EntityTypeItem) { return ItemPlayerTouch(entity, player); }
-	if (entity->Type == EntityTypePrimedTNT) { return PrimedTNTPlayerTouch(entity, player); }
-	if (entity->Type == EntityTypeArrow) { return ArrowPlayerTouch(entity, player); }
+	if (entity->Type == EntityTypeItem) { ItemPlayerTouch(entity, player); return; }
+	if (entity->Type == EntityTypePrimedTNT) { PrimedTNTPlayerTouch(entity, player); return; }
+	if (entity->Type == EntityTypeArrow) { ArrowPlayerTouch(entity, player); return; }
 }
 
 void EntityPush(Entity entityA, Entity entityB)
@@ -359,8 +359,8 @@ void EntityPushTowards(Entity entity, float3 point)
 
 void EntityHurt(Entity entityA, Entity entityB, int damage)
 {
-	if (entityA->Type == EntityTypePrimedTNT) { return PrimedTNTHurt(entityA, entityB, damage); }
-	if (entityA->Type == EntityTypeMob) { return MobHurt(entityA, entityB, damage); }
+	if (entityA->Type == EntityTypePrimedTNT) { PrimedTNTHurt(entityA, entityB, damage); return; }
+	if (entityA->Type == EntityTypeMob) { MobHurt(entityA, entityB, damage); return; }
 }
 
 bool EntityIntersects(Entity entity, float3 v0, float3 v1)
@@ -389,8 +389,8 @@ bool EntityIsShootable(Entity entity)
 
 void EntityAwardKillScore(Entity entityA, Entity entityB, int score)
 {
-	if (entityA->Type == EntityTypeArrow) { return ArrowAwardKillScore(entityA, entityB, score); }
-	if (entityA->Type == EntityTypeMob && ((MobData)entityA->TypeData)->Type == MobTypePlayer) { return PlayerAwardKillScore(entityA, entityB, score); }
+	if (entityA->Type == EntityTypeArrow) { ArrowAwardKillScore(entityA, entityB, score); return; }
+	if (entityA->Type == EntityTypeMob && ((MobData)entityA->TypeData)->Type == MobTypePlayer) { PlayerAwardKillScore(entityA, entityB, score); return; }
 }
 
 bool EntityShouldRender(Entity entity, float3 v)

--- a/MinecraftC/GUI/GUIScreen.c
+++ b/MinecraftC/GUI/GUIScreen.c
@@ -27,17 +27,17 @@ GUIScreen GUIScreenCreate()
 
 void GUIScreenRender(GUIScreen screen, int2 m)
 {
-	if (screen->Type == GUIScreenTypeBlockSelect) { return BlockSelectScreenRender(screen, m); }
-	if (screen->Type == GUIScreenTypeChatInput) { return ChatInputScreenRender(screen, m); }
+	if (screen->Type == GUIScreenTypeBlockSelect) { BlockSelectScreenRender(screen, m); return; }
+	if (screen->Type == GUIScreenTypeChatInput) { ChatInputScreenRender(screen, m); return; }
 	if (screen->Type == GUIScreenTypeControls) { ControlsScreenRender(screen, m); }
 	if (screen->Type == GUIScreenTypeError) { ErrorScreenRender(screen, m); }
 	if (screen->Type == GUIScreenTypeGameOver) { GameOverScreenRender(screen, m); }
 	if (screen->Type == GUIScreenTypeGenerateLevel) { GenerateLevelScreenRender(screen, m); }
 	if (screen->Type == GUIScreenTypeLevelName) { LevelNameScreenRender(screen, m); }
-	if (screen->Type == GUIScreenTypeLoadLevel) { return LoadLevelScreenRender(screen, m); }
+	if (screen->Type == GUIScreenTypeLoadLevel) { LoadLevelScreenRender(screen, m); return; }
 	if (screen->Type == GUIScreenTypeOptions) { OptionsScreenRender(screen, m); }
 	if (screen->Type == GUIScreenTypePause) { PauseScreenRender(screen, m); }
-	if (screen->Type == GUIScreenTypeSaveLevel) { return LoadLevelScreenRender(screen, m); }
+	if (screen->Type == GUIScreenTypeSaveLevel) { LoadLevelScreenRender(screen, m); return; }
 	
 	for (int i = 0; i < ListCount(screen->Buttons); i++)
 	{
@@ -62,10 +62,10 @@ void GUIScreenRender(GUIScreen screen, int2 m)
 
 void GUIScreenOnKeyPressed(GUIScreen screen, char eventChar, int eventKey)
 {
-	if (screen->Type == GUIScreenTypeChatInput) { return ChatInputScreenOnKeyPressed(screen, eventChar, eventKey); }
-	if (screen->Type == GUIScreenTypeControls) { return ControlsScreenOnKeyPressed(screen, eventChar, eventKey); }
-	if (screen->Type == GUIScreenTypeError) { return ErrorScreenOnKeyPressed(screen, eventChar, eventKey); }
-	if (screen->Type == GUIScreenTypeLevelName) { return LevelNameScreenOnKeyPressed(screen, eventChar, eventKey); }
+	if (screen->Type == GUIScreenTypeChatInput) { ChatInputScreenOnKeyPressed(screen, eventChar, eventKey); return; }
+	if (screen->Type == GUIScreenTypeControls) { ControlsScreenOnKeyPressed(screen, eventChar, eventKey); return; }
+	if (screen->Type == GUIScreenTypeError) { ErrorScreenOnKeyPressed(screen, eventChar, eventKey); return; }
+	if (screen->Type == GUIScreenTypeLevelName) { LevelNameScreenOnKeyPressed(screen, eventChar, eventKey); return; }
 	if (eventKey == SDL_SCANCODE_ESCAPE)
 	{
 		MinecraftGrabMouse(screen->Minecraft);
@@ -75,8 +75,8 @@ void GUIScreenOnKeyPressed(GUIScreen screen, char eventChar, int eventKey)
 
 void GUIScreenOnMouseClicked(GUIScreen screen, int x, int y, int button)
 {
-	if (screen->Type == GUIScreenTypeBlockSelect) { return BlockSelectScreenOnMouseClicked(screen, x, y, button); }
-	if (screen->Type == GUIScreenTypeChatInput) { return ChatInputScreenOnMouseClicked(screen, x, y, button); }
+	if (screen->Type == GUIScreenTypeBlockSelect) { BlockSelectScreenOnMouseClicked(screen, x, y, button); return; }
+	if (screen->Type == GUIScreenTypeChatInput) { ChatInputScreenOnMouseClicked(screen, x, y, button); return; }
 	if (button == SDL_BUTTON_LEFT)
 	{
 		for (int i = 0; i < ListCount(screen->Buttons); i++)
@@ -89,14 +89,14 @@ void GUIScreenOnMouseClicked(GUIScreen screen, int x, int y, int button)
 
 void GUIScreenOnButtonClicked(GUIScreen screen, Button button)
 {
-	if (screen->Type == GUIScreenTypeControls) { return ControlsScreenOnButtonClicked(screen, button); }
-	if (screen->Type == GUIScreenTypeGameOver) { return GameOverScreenOnButtonClicked(screen, button); }
-	if (screen->Type == GUIScreenTypeGenerateLevel) { return GenerateLevelScreenOnButtonClicked(screen, button); }
-	if (screen->Type == GUIScreenTypeLevelName) { return LevelNameScreenOnButtonClicked(screen, button); }
-	if (screen->Type == GUIScreenTypeLoadLevel) { return LoadLevelScreenOnButtonClicked(screen, button); }
-	if (screen->Type == GUIScreenTypeOptions) { return OptionsScreenOnButtonClicked(screen, button); }
-	if (screen->Type == GUIScreenTypePause) { return PauseScreenOnButtonClicked(screen, button); }
-	if (screen->Type == GUIScreenTypeSaveLevel) { return LoadLevelScreenOnButtonClicked(screen, button); }
+	if (screen->Type == GUIScreenTypeControls) { ControlsScreenOnButtonClicked(screen, button); return; }
+	if (screen->Type == GUIScreenTypeGameOver) { GameOverScreenOnButtonClicked(screen, button); return; }
+	if (screen->Type == GUIScreenTypeGenerateLevel) { GenerateLevelScreenOnButtonClicked(screen, button); return; }
+	if (screen->Type == GUIScreenTypeLevelName) { LevelNameScreenOnButtonClicked(screen, button); return; }
+	if (screen->Type == GUIScreenTypeLoadLevel) { LoadLevelScreenOnButtonClicked(screen, button); return; }
+	if (screen->Type == GUIScreenTypeOptions) { OptionsScreenOnButtonClicked(screen, button); return; }
+	if (screen->Type == GUIScreenTypePause) { PauseScreenOnButtonClicked(screen, button); return; }
+	if (screen->Type == GUIScreenTypeSaveLevel) { LoadLevelScreenOnButtonClicked(screen, button); return; }
 }
 
 void GUIScreenOpen(GUIScreen screen, Minecraft minecraft, int width, int height)
@@ -110,16 +110,16 @@ void GUIScreenOpen(GUIScreen screen, Minecraft minecraft, int width, int height)
 
 void GUIScreenOnOpen(GUIScreen screen)
 {
-	if (screen->Type == GUIScreenTypeChatInput) { return ChatInputScreenOnOpen(screen); }
-	if (screen->Type == GUIScreenTypeControls) { return ControlsScreenOnOpen(screen); }
-	if (screen->Type == GUIScreenTypeError) { return ErrorScreenOnOpen(screen); }
-	if (screen->Type == GUIScreenTypeGameOver) { return GameOverScreenOnOpen(screen); }
-	if (screen->Type == GUIScreenTypeGenerateLevel) { return GenerateLevelScreenOnOpen(screen); }
-	if (screen->Type == GUIScreenTypeLevelName) { return LevelNameScreenOnOpen(screen); }
-	if (screen->Type == GUIScreenTypeLoadLevel) { return LoadLevelScreenOnOpen(screen); }
-	if (screen->Type == GUIScreenTypeOptions) { return OptionsScreenOnOpen(screen); }
-	if (screen->Type == GUIScreenTypePause) { return PauseScreenOnOpen(screen); }
-	if (screen->Type == GUIScreenTypeSaveLevel) { return LoadLevelScreenOnOpen(screen); }
+	if (screen->Type == GUIScreenTypeChatInput) { ChatInputScreenOnOpen(screen); return; }
+	if (screen->Type == GUIScreenTypeControls) { ControlsScreenOnOpen(screen); return; }
+	if (screen->Type == GUIScreenTypeError) { ErrorScreenOnOpen(screen); return; }
+	if (screen->Type == GUIScreenTypeGameOver) { GameOverScreenOnOpen(screen); return; }
+	if (screen->Type == GUIScreenTypeGenerateLevel) { GenerateLevelScreenOnOpen(screen); return; }
+	if (screen->Type == GUIScreenTypeLevelName) { LevelNameScreenOnOpen(screen); return; }
+	if (screen->Type == GUIScreenTypeLoadLevel) { LoadLevelScreenOnOpen(screen); return; }
+	if (screen->Type == GUIScreenTypeOptions) { OptionsScreenOnOpen(screen); return; }
+	if (screen->Type == GUIScreenTypePause) { PauseScreenOnOpen(screen); return; }
+	if (screen->Type == GUIScreenTypeSaveLevel) { LoadLevelScreenOnOpen(screen); return; }
 }
 
 void GUIScreenDoInput(GUIScreen screen, list(SDL_Event) events)
@@ -151,18 +151,18 @@ void GUIScreenKeyboardEvent(GUIScreen screen, SDL_Event event)
 
 void GUIScreenTick(GUIScreen screen)
 {
-	if (screen->Type == GUIScreenTypeChatInput) { return ChatInputScreenTick(screen); }
-	if (screen->Type == GUIScreenTypeLevelName) { return LevelNameScreenTick(screen); }
-	if (screen->Type == GUIScreenTypeLoadLevel) { return LoadLevelScreenTick(screen); }
-	if (screen->Type == GUIScreenTypeSaveLevel) { return LoadLevelScreenTick(screen); }
+	if (screen->Type == GUIScreenTypeChatInput) { ChatInputScreenTick(screen); return; }
+	if (screen->Type == GUIScreenTypeLevelName) { LevelNameScreenTick(screen); return; }
+	if (screen->Type == GUIScreenTypeLoadLevel) { LoadLevelScreenTick(screen); return; }
+	if (screen->Type == GUIScreenTypeSaveLevel) { LoadLevelScreenTick(screen); return; }
 }
 
 void GUIScreenOnClose(GUIScreen screen)
 {
-	if (screen->Type == GUIScreenTypeChatInput) { return ChatInputScreenOnClose(screen); }
-	if (screen->Type == GUIScreenTypeLevelName) { return LevelNameScreenOnClose(screen); }
-	if (screen->Type == GUIScreenTypeLoadLevel) { return LoadLevelScreenOnClose(screen); }
-	if (screen->Type == GUIScreenTypeSaveLevel) { return LoadLevelScreenOnClose(screen); }
+	if (screen->Type == GUIScreenTypeChatInput) { ChatInputScreenOnClose(screen); return; }
+	if (screen->Type == GUIScreenTypeLevelName) { LevelNameScreenOnClose(screen); return; }
+	if (screen->Type == GUIScreenTypeLoadLevel) { LoadLevelScreenOnClose(screen); return; }
+	if (screen->Type == GUIScreenTypeSaveLevel) { LoadLevelScreenOnClose(screen); return; }
 }
 
 void GUIScreenDestroy(GUIScreen screen)

--- a/MinecraftC/GUI/LoadLevelScreen.c
+++ b/MinecraftC/GUI/LoadLevelScreen.c
@@ -29,7 +29,7 @@ void LoadLevelScreenRun(LoadLevelScreen screen)
 
 void LoadLevelScreenSetLevels(LoadLevelScreen screen, char * levels[5])
 {
-	if (screen->Type == GUIScreenTypeSaveLevel) { return SaveLevelScreenSetLevels(screen, levels); }
+	if (screen->Type == GUIScreenTypeSaveLevel) { SaveLevelScreenSetLevels(screen, levels); return; }
 	for (int i = 0; i < 5; i++)
 	{
 		screen->Buttons[i]->Active = !(strcmp(levels[i], "-") == 0);
@@ -49,7 +49,7 @@ void LoadLevelScreenOnOpen(LoadLevelScreen screen)
 	}
 	screen->Buttons = ListPush(screen->Buttons, &(Button){ ButtonCreate(5, screen->Width / 2 - 100, screen->Height / 6 + 132, "Load file...") });
 	screen->Buttons = ListPush(screen->Buttons, &(Button){ ButtonCreate(6, screen->Width / 2 - 100, screen->Height / 6 + 168, "Cancel") });
-	if (screen->Type == GUIScreenTypeSaveLevel) { return SaveLevelScreenOnOpen(screen); }
+	if (screen->Type == GUIScreenTypeSaveLevel) { SaveLevelScreenOnOpen(screen); return; }
 }
 
 void LoadLevelScreenOnButtonClicked(LoadLevelScreen screen, Button button)
@@ -78,7 +78,7 @@ void LoadLevelScreenOnButtonClicked(LoadLevelScreen screen, Button button)
 
 void LoadLevelScreenOpenLevel(LoadLevelScreen screen, int level)
 {
-	if (screen->Type == GUIScreenTypeSaveLevel) { return SaveLevelScreenOpenLevel(screen, level); }
+	if (screen->Type == GUIScreenTypeSaveLevel) { SaveLevelScreenOpenLevel(screen, level); return; }
 	MinecraftLoadOnlineLevel(screen->Minecraft, screen->Minecraft->Session->UserName, level);
 	MinecraftSetCurrentScreen(screen->Minecraft, NULL);
 	MinecraftGrabMouse(screen->Minecraft);
@@ -86,7 +86,7 @@ void LoadLevelScreenOpenLevel(LoadLevelScreen screen, int level)
 
 void LoadLevelScreenOpenLevelFromFile(LoadLevelScreen screen, char * file)
 {
-	if (screen->Type == GUIScreenTypeSaveLevel) { return SaveLevelScreenOpenLevelFromFile(screen, file); }
+	if (screen->Type == GUIScreenTypeSaveLevel) { SaveLevelScreenOpenLevelFromFile(screen, file); return; }
 	LoadLevelScreenData this = screen->TypeData;
 	Level level = LevelIOLoad(screen->Minecraft->LevelIO, SDL_RWFromFile(file, "rb"));
 	if (level != NULL) { MinecraftSetLevel(screen->Minecraft, level); }
@@ -126,7 +126,7 @@ void LoadLevelScreenRender(LoadLevelScreen screen, int2 mousePos)
 		GUIScreenRender(screen, mousePos);
 		screen->Type = GUIScreenTypeLoadLevel;
 	}
-	if (screen->Type == GUIScreenTypeSaveLevel) { return SaveLevelScreenRender(screen, mousePos); }
+	if (screen->Type == GUIScreenTypeSaveLevel) { SaveLevelScreenRender(screen, mousePos); return; }
 }
 
 void LoadLevelScreenDestroy(LoadLevelScreen screen)

--- a/MinecraftC/GameMode/GameMode.c
+++ b/MinecraftC/GameMode/GameMode.c
@@ -23,12 +23,12 @@ void GameModeApply(GameMode mode, Level level)
 
 void GameModeOpenInventory(GameMode mode)
 {
-	if (mode->Type == GameModeTypeCreative) { return CreativeModeOpenInventory(mode); }
+	if (mode->Type == GameModeTypeCreative) { CreativeModeOpenInventory(mode); return; }
 }
 
 void GameModeHitBlock(GameMode mode, int x, int y, int z)
 {
-	if (mode->Type == GameModeTypeSurvival) { return SurvivalModeHitBlock(mode, x, y, z); }
+	if (mode->Type == GameModeTypeSurvival) { SurvivalModeHitBlock(mode, x, y, z); return; }
 	GameModeBreakBlock(mode, x, y, z);
 }
 
@@ -63,17 +63,17 @@ void GameModeBreakBlock(GameMode mode, int x, int y, int z)
 
 void GameModeHitBlockSide(GameMode mode, int x, int y, int z, int side)
 {
-	if (mode->Type == GameModeTypeSurvival) { return SurvivalModeHitBlockSide(mode, x, y, z, side); }
+	if (mode->Type == GameModeTypeSurvival) { SurvivalModeHitBlockSide(mode, x, y, z, side); return; }
 }
 
 void GameModeResetHits(GameMode mode)
 {
-	if (mode->Type == GameModeTypeSurvival) { return SurvivalModeResetHits(mode); }
+	if (mode->Type == GameModeTypeSurvival) { SurvivalModeResetHits(mode); return; }
 }
 
 void GameModeApplyCracks(GameMode mode, float cracks)
 {
-	if (mode->Type == GameModeTypeSurvival) { return SurvivalModeApplyCracks(mode, cracks); }
+	if (mode->Type == GameModeTypeSurvival) { SurvivalModeApplyCracks(mode, cracks); return; }
 }
 
 float GameModeGetReachDistance(GameMode mode)
@@ -90,17 +90,17 @@ bool GameModeUseItem(GameMode mode, Player player, BlockType blockType)
 
 void GameModePreparePlayer(GameMode mode, Player player)
 {
-	if (mode->Type == GameModeTypeSurvival) { return SurvivalModePreparePlayer(mode, player); }
+	if (mode->Type == GameModeTypeSurvival) { SurvivalModePreparePlayer(mode, player); return; }
 }
 
 void GameModeSpawnMob(GameMode mode)
 {
-	if (mode->Type == GameModeTypeSurvival) { return SurvivalModeSpawnMob(mode); }
+	if (mode->Type == GameModeTypeSurvival) { SurvivalModeSpawnMob(mode); return; }
 }
 
 void GameModePrepareLevel(GameMode mode, Level level)
 {
-	if (mode->Type == GameModeTypeSurvival) { return SurvivalModePrepareLevel(mode, level); }
+	if (mode->Type == GameModeTypeSurvival) { SurvivalModePrepareLevel(mode, level); return; }
 }
 
 bool GameModeIsSurvival(GameMode mode)
@@ -111,7 +111,7 @@ bool GameModeIsSurvival(GameMode mode)
 
 void GameModeApplyPlayer(GameMode mode, Player player)
 {
-	if (mode->Type == GameModeTypeCreative) { return CreativeModeApplyPlayer(mode, player); }
+	if (mode->Type == GameModeTypeCreative) { CreativeModeApplyPlayer(mode, player); return; }
 }
 
 void GameModeDestroy(GameMode mode)

--- a/MinecraftC/Level/Tile/Block.c
+++ b/MinecraftC/Level/Tile/Block.c
@@ -139,7 +139,7 @@ void BlockSetTickDelay(Block block, int tickDelay)
 
 void BlockRenderFullBrightness(Block block)
 {
-	if (IsFlowerBlock(block->Type)) { return FlowerBlockRenderFullBrightness(block); }
+	if (IsFlowerBlock(block->Type)) { FlowerBlockRenderFullBrightness(block); return; }
 	
 	ShapeRendererColor(one3f * 0.5);
 	BlockRenderInside(block, -2, 0, 0, 0);
@@ -291,9 +291,9 @@ bool BlockIsSolid(Block block)
 
 void BlockUpdate(Block block, Level level, int x, int y, int z, RandomGenerator random)
 {
-	if (IsFlowerBlock(block->Type)) { return FlowerBlockUpdate(block, level, x, y, z, random); }
-	if (block->Type == BlockTypeGrass) { return GrassBlockUpdate(block, level, x, y, z, random); }
-	if (IsLiquidBlock(block->Type)) { return LiquidBlockUpdate(block, level, x, y, z, random); }
+	if (IsFlowerBlock(block->Type)) { FlowerBlockUpdate(block, level, x, y, z, random); return; }
+	if (block->Type == BlockTypeGrass) { GrassBlockUpdate(block, level, x, y, z, random); return; }
+	if (IsLiquidBlock(block->Type)) { LiquidBlockUpdate(block, level, x, y, z, random); return; }
 }
 
 void BlockSpawnBreakParticles(Block block, Level level, int x, int y, int z, ParticleManager particles)
@@ -337,15 +337,15 @@ LiquidType BlockGetLiquidType(Block block)
 
 void BlockOnNeighborChanged(Block block, Level level, int x, int y, int z, BlockType tile)
 {
-	if (IsLiquidBlock(block->Type)) { return LiquidBlockOnNeighborChanged(block, level, x, y, z, tile); }
-	if (IsSandBlock(block->Type)) { return SandBlockOnNeighborChanged(block, level, x, y, z, tile); }
-	if (IsSlabBlock(block->Type)) { return SlabBlockOnNeighborChanged(block, level, x, y, z, tile); }
+	if (IsLiquidBlock(block->Type)) { LiquidBlockOnNeighborChanged(block, level, x, y, z, tile); return; }
+	if (IsSandBlock(block->Type)) { SandBlockOnNeighborChanged(block, level, x, y, z, tile); return; }
+	if (IsSlabBlock(block->Type)) { SlabBlockOnNeighborChanged(block, level, x, y, z, tile); return; }
 }
 
 void BlockOnPlaced(Block block, Level level, int x, int y, int z)
 {
-	if (IsLiquidBlock(block->Type)) { return LiquidBlockOnPlaced(block, level, x, y, z); }
-	if (IsSandBlock(block->Type)) { return SandBlockOnPlaced(block, level, x, y, z); }
+	if (IsLiquidBlock(block->Type)) { LiquidBlockOnPlaced(block, level, x, y, z); return; }
+	if (IsSandBlock(block->Type)) { SandBlockOnPlaced(block, level, x, y, z); return; }
 }
 
 int BlockGetTickDelay(Block block)
@@ -356,13 +356,13 @@ int BlockGetTickDelay(Block block)
 
 void BlockOnAdded(Block block, Level level, int x, int y, int z)
 {
-	if (IsSlabBlock(block->Type)) { return SlabBlockOnAdded(block, level, x, y, z); }
-	if (block->Type == BlockTypeSponge) { return SpongeBlockOnAdded(block, level, x, y, z); }
+	if (IsSlabBlock(block->Type)) { SlabBlockOnAdded(block, level, x, y, z); return; }
+	if (block->Type == BlockTypeSponge) { SpongeBlockOnAdded(block, level, x, y, z); return; }
 }
 
 void BlockOnRemoved(Block block, Level level, int x, int y, int z)
 {
-	if (block->Type == BlockTypeSponge) { return SpongeBlockOnRemoved(block, level, x, y, z); }
+	if (block->Type == BlockTypeSponge) { SpongeBlockOnRemoved(block, level, x, y, z); return; }
 }
 
 int BlockGetDropCount(Block block)
@@ -394,13 +394,13 @@ int BlockGetHardness(Block block)
 
 void BlockOnBreak(Block block, Level level, int x, int y, int z)
 {
-	if (IsLiquidBlock(block->Type)) { return LiquidBlockOnBreak(block, level, x, y, z); }
+	if (IsLiquidBlock(block->Type)) { LiquidBlockOnBreak(block, level, x, y, z); return; }
 	BlockDropItems(block, level, x, y, z, 1.0);
 }
 
 void BlockDropItems(Block block, Level level, int x, int y, int z, float probability)
 {
-	if (IsLiquidBlock(block->Type)) { return LiquidBlockDropItems(block, level, x, y, z, probability); }
+	if (IsLiquidBlock(block->Type)) { LiquidBlockDropItems(block, level, x, y, z, probability); return; }
 	
 	if (!level->CreativeMode)
 	{
@@ -419,7 +419,7 @@ void BlockDropItems(Block block, Level level, int x, int y, int z, float probabi
 
 void BlockRenderPreview(Block block)
 {
-	if (IsFlowerBlock(block->Type)) { return FlowerBlockRenderPreview(block); }
+	if (IsFlowerBlock(block->Type)) { FlowerBlockRenderPreview(block); return; }
 	ShapeRendererBegin();
 	for (int i = 0; i < 6; i++)
 	{
@@ -452,7 +452,7 @@ MovingObjectPosition BlockClip(Block block, int x, int y, int z, float3 v1, floa
 
 void BlockExplode(Block block, Level level, int x, int y, int z)
 {
-	if (block->Type == BlockTypeTNT) { return TNTBlockExplode(block, level, x, y, z); }
+	if (block->Type == BlockTypeTNT) { TNTBlockExplode(block, level, x, y, z); return; }
 }
 
 bool BlockRender(Block block, Level level, int x, int y, int z)

--- a/MinecraftC/Level/Tile/FlowerBlock.c
+++ b/MinecraftC/Level/Tile/FlowerBlock.c
@@ -16,8 +16,8 @@ FlowerBlock FlowerBlockCreate(BlockType type, int textureID)
 
 void FlowerBlockUpdate(FlowerBlock block, Level level, int x, int y, int z, RandomGenerator random)
 {
-	if (block->Type == BlockTypeRedMushroom || block->Type == BlockTypeBrownMushroom) { return MushroomBlockUpdate(block, level, x, y, z, random); }
-	if (block->Type == BlockTypeSapling) { return SaplingBlockUpdate(block, level, x, y, z, random); }
+	if (block->Type == BlockTypeRedMushroom || block->Type == BlockTypeBrownMushroom) { MushroomBlockUpdate(block, level, x, y, z, random); return; }
+	if (block->Type == BlockTypeSapling) { SaplingBlockUpdate(block, level, x, y, z, random); return; }
 	
 	if (!level->GrowTrees)
 	{

--- a/MinecraftC/Level/Tile/LiquidBlock.c
+++ b/MinecraftC/Level/Tile/LiquidBlock.c
@@ -61,7 +61,7 @@ static bool Flow(LiquidBlock block, Level level, int x, int y, int z)
 
 void LiquidBlockUpdate(LiquidBlock block, Level level, int x, int y, int z, RandomGenerator random)
 {
-	if (block->Type == BlockTypeStillWater || block->Type == BlockTypeStillLava) { return StillLiquidBlockUpdate(block, level, x, y, z, random); }
+	if (block->Type == BlockTypeStillWater || block->Type == BlockTypeStillLava) { StillLiquidBlockUpdate(block, level, x, y, z, random); return; }
 		
 	LiquidBlockData liquid = block->TypeData;
 	bool set = false;
@@ -133,7 +133,7 @@ LiquidType LiquidBlockGetLiquidType(LiquidBlock block)
 
 void LiquidBlockOnNeighborChanged(LiquidBlock block, Level level, int x, int y, int z, BlockType tile)
 {
-	if (block->Type == BlockTypeStillWater || block->Type == BlockTypeStillLava) { return StillLiquidBlockOnNeighborChanged(block, level, x, y, z, tile); }
+	if (block->Type == BlockTypeStillWater || block->Type == BlockTypeStillLava) { StillLiquidBlockOnNeighborChanged(block, level, x, y, z, tile); return; }
 	
 	LiquidBlockData this = block->TypeData;
 	if (tile != BlockTypeNone)

--- a/MinecraftC/Mob/AI/AI.c
+++ b/MinecraftC/Mob/AI/AI.c
@@ -10,17 +10,17 @@ AI AICreate(void)
 
 void AITick(AI ai, Level level, Entity mob)
 {
-	if (ai->Type == AITypeBasic) { return BasicAITick(ai, level, mob); }
+	if (ai->Type == AITypeBasic) { BasicAITick(ai, level, mob); return; }
 }
 
 void AIBeforeRemove(AI ai)
 {
-	if (ai->Type == AITypeBasic) { return BasicAIBeforeRemove(ai); }
+	if (ai->Type == AITypeBasic) { BasicAIBeforeRemove(ai); return; }
 }
 
 void AIHurt(AI ai, Entity entity, int damage)
 {
-	if (ai->Type == AITypeBasic) { return BasicAIHurt(ai, entity, damage); }
+	if (ai->Type == AITypeBasic) { BasicAIHurt(ai, entity, damage); return; }
 }
 
 void AIDestroy(AI ai)

--- a/MinecraftC/Mob/AI/BasicAI.c
+++ b/MinecraftC/Mob/AI/BasicAI.c
@@ -72,15 +72,15 @@ void BasicAITick(BasicAI ai, Level level, Entity mob)
 void BasicAIJumpFromGround(BasicAI ai)
 {
 	BasicAIData this = ai->TypeData;
-	if (this->Type == BasicAITypeBasicAttack && ((BasicAttackAIData)this->TypeData)->Type == BasicAttackAIJumpAttack && this->AttackTarget != NULL) { return JumpAttackAIJumpFromGround(ai); }
+	if (this->Type == BasicAITypeBasicAttack && ((BasicAttackAIData)this->TypeData)->Type == BasicAttackAIJumpAttack && this->AttackTarget != NULL) { JumpAttackAIJumpFromGround(ai); return; }
 	this->Mob->Delta.y = 0.42;
 }
 
 void BasicAIUpdate(BasicAI ai)
 {
 	BasicAIData this = ai->TypeData;
-	if (this->Type == BasicAITypeSheep) { return SheepAIUpdate(ai); }
-	if (this->Type == BasicAITypePlayer) { return PlayerAIUpdate(ai); }
+	if (this->Type == BasicAITypeSheep) { SheepAIUpdate(ai); return; }
+	if (this->Type == BasicAITypePlayer) { PlayerAIUpdate(ai); return; }
 	
 	if (RandomGeneratorUniform(this->Random) < 0.07) { this->XY = (float2){ RandomGeneratorUniform(this->Random) - 0.5, RandomGeneratorUniform(this->Random) } * this->RunSpeed; }
 	this->Jumping = RandomGeneratorUniform(this->Random) < 0.01;
@@ -101,8 +101,8 @@ void BasicAIUpdate(BasicAI ai)
 void BasicAIBeforeRemove(BasicAI ai)
 {
 	BasicAIData this = ai->TypeData;
-	if (this->Type == BasicAITypeBasicAttack && ((BasicAttackAIData)this->TypeData)->Type == BasicAttackAITypeCreeper) { return CreeperAIBeforeRemove(ai); }
-	if (this->Type == BasicAITypeBasicAttack && ((BasicAttackAIData)this->TypeData)->Type == BasicAttackAITypeSkeleton) { return SkeletonAIBeforeRemove(ai); }
+	if (this->Type == BasicAITypeBasicAttack && ((BasicAttackAIData)this->TypeData)->Type == BasicAttackAITypeCreeper) { CreeperAIBeforeRemove(ai); return; }
+	if (this->Type == BasicAITypeBasicAttack && ((BasicAttackAIData)this->TypeData)->Type == BasicAttackAITypeSkeleton) { SkeletonAIBeforeRemove(ai); return; }
 }
 
 void BasicAIHurt(BasicAI ai, Entity entity, int damage)

--- a/MinecraftC/Mob/Mob.c
+++ b/MinecraftC/Mob/Mob.c
@@ -125,7 +125,7 @@ void MobTick(Mob mob)
 void MobStepAI(Mob mob)
 {
 	MobData this = mob->TypeData;
-	if (this->Type == MobTypePlayer) { return PlayerStepAI(mob); }
+	if (this->Type == MobTypePlayer) { PlayerStepAI(mob); return; }
 	if (this->AI != NULL) { AITick(this->AI, mob->Level, mob); }
 	if (this->Type == MobTypeSheep) { SheepStepAI(mob); }
 }
@@ -133,7 +133,7 @@ void MobStepAI(Mob mob)
 void MobBindTexture(Mob mob, TextureManager textures)
 {
 	MobData this = mob->TypeData;
-	if (this->Type == MobTypePlayer) { return PlayerBindTexture(mob, textures); }
+	if (this->Type == MobTypePlayer) { PlayerBindTexture(mob, textures); return; }
 	mob->TextureID = TextureManagerLoad(textures, (char *)this->TextureName);
 	glBindTexture(GL_TEXTURE_2D, mob->TextureID);
 }
@@ -141,7 +141,7 @@ void MobBindTexture(Mob mob, TextureManager textures)
 void MobRender(Mob mob, TextureManager textures, float t)
 {
 	MobData this = mob->TypeData;
-	if (this->Type == MobTypePlayer) { return PlayerRender(mob, textures, t); }
+	if (this->Type == MobTypePlayer) { PlayerRender(mob, textures, t); return; }
 	if (this->ModelName == NULL) { return; }
 	
 	float attack = this->AttackTime - t;
@@ -211,7 +211,7 @@ void MobRender(Mob mob, TextureManager textures, float t)
 void MobRenderModel(Mob mob, TextureManager textures, float anim, float t, float run, float2 rot, float offset)
 {
 	MobData this = mob->TypeData;
-	if (this->Type == MobTypeSheep) { return SheepRenderModel(mob, textures, anim, t, run, rot, offset); }
+	if (this->Type == MobTypeSheep) { SheepRenderModel(mob, textures, anim, t, run, rot, offset); return; }
 	ModelRender(ModelManagerGetModel(MobModelCache, this->ModelName), anim, run, this->TickCount + t, rot, offset);
 	if (this->Type == MobTypeHumanoid || this->Type == MobTypeSkeleton || this->Type == MobTypeZombie) { HumanoidRenderModel(mob, textures, anim, t, run, rot, offset); }
 }
@@ -230,8 +230,8 @@ void MobHeal(Mob mob, int health)
 void MobHurt(Mob mob, Entity entity, int damage)
 {
 	MobData this = mob->TypeData;
-	if (this->Type == MobTypeSheep && ((SheepData)this->TypeData)->HasFur && entity != NULL && ((MobData)entity->TypeData)->Type == MobTypePlayer) { return SheepHurt(mob, entity, damage); }
-	if (this->Type == MobTypePlayer) { return PlayerHurt(mob, entity, damage); }
+	if (this->Type == MobTypeSheep && ((SheepData)this->TypeData)->HasFur && entity != NULL && ((MobData)entity->TypeData)->Type == MobTypePlayer) { SheepHurt(mob, entity, damage); return; }
+	if (this->Type == MobTypePlayer) { PlayerHurt(mob, entity, damage); return; }
 	
 	if (mob->Level->CreativeMode) { return; }
 	if (this->Health <= 0) { return; }
@@ -276,7 +276,7 @@ void MobDie(Mob mob, Entity entity)
 	MobData this = mob->TypeData;
 	if (this->Type == MobTypePig) { PigDie(mob, entity); }
 	if (this->Type == MobTypeSheep) { SheepDie(mob, entity); }
-	if (this->Type == MobTypePlayer) { return PlayerDie(mob, entity); }
+	if (this->Type == MobTypePlayer) { PlayerDie(mob, entity); return; }
 	
 	if (!mob->Level->CreativeMode)
 	{

--- a/MinecraftC/Model/Model.c
+++ b/MinecraftC/Model/Model.c
@@ -14,15 +14,15 @@ Model ModelCreate()
 
 void ModelRender(Model model, float anim, float t, float run, float2 rot, float offset)
 {
-	if (model->Type == ModelTypeAnimal) { return AnimalModelRender(model, anim, t, run, rot, offset); }
-	if (model->Type == ModelTypeCreeper) { return CreeperModelRender(model, anim, t, run, rot, offset); }
-	if (model->Type == ModelTypeHumanoid) { return HumanoidModelRender(model, anim, t, run, rot, offset); }
-	if (model->Type == ModelTypePig) { return AnimalModelRender(model, anim, t, run, rot, offset); }
-	if (model->Type == ModelTypeSheepFur) { return AnimalModelRender(model, anim, t, run, rot, offset); }
-	if (model->Type == ModelTypeSheep) { return AnimalModelRender(model, anim, t, run, rot, offset); }
-	if (model->Type == ModelTypeSkeleton) { return HumanoidModelRender(model, anim, t, run, rot, offset); }
-	if (model->Type == ModelTypeSpider) { return SpiderModelRender(model, anim, t, run, rot, offset); }
-	if (model->Type == ModelTypeZombie) { return HumanoidModelRender(model, anim, t, run, rot, offset); }
+	if (model->Type == ModelTypeAnimal) { AnimalModelRender(model, anim, t, run, rot, offset); return; }
+	if (model->Type == ModelTypeCreeper) { CreeperModelRender(model, anim, t, run, rot, offset); return; }
+	if (model->Type == ModelTypeHumanoid) { HumanoidModelRender(model, anim, t, run, rot, offset); return; }
+	if (model->Type == ModelTypePig) { AnimalModelRender(model, anim, t, run, rot, offset); return; }
+	if (model->Type == ModelTypeSheepFur) { AnimalModelRender(model, anim, t, run, rot, offset); return; }
+	if (model->Type == ModelTypeSheep) { AnimalModelRender(model, anim, t, run, rot, offset); return; }
+	if (model->Type == ModelTypeSkeleton) { HumanoidModelRender(model, anim, t, run, rot, offset); return; }
+	if (model->Type == ModelTypeSpider) { SpiderModelRender(model, anim, t, run, rot, offset); return; }
+	if (model->Type == ModelTypeZombie) { HumanoidModelRender(model, anim, t, run, rot, offset); return; }
 }
 
 void ModelDestroy(Model model)

--- a/MinecraftC/Particle/Particle.c
+++ b/MinecraftC/Particle/Particle.c
@@ -63,7 +63,7 @@ void ParticleTick(Particle particle)
 void ParticleRender(Particle particle, float t, float3 v1, float v6, float v7)
 {
 	ParticleData this = particle->TypeData;
-	if (this->Type == ParticleTypeTerrain) { return TerrainParticleRender(particle, t, v1, v6, v7); }
+	if (this->Type == ParticleTypeTerrain) { TerrainParticleRender(particle, t, v1, v6, v7); return; }
 
 	float2 uv0 = { ((this->Texture % 16) + this->UV.x / 4.0F) / 16.0F, ((this->Texture / 16) + this->UV.y / 4.0F) / 16.0F };
 	float2 uv1 = uv0 + 0.0624375;

--- a/MinecraftC/Render/Texture/AnimatedTexture.c
+++ b/MinecraftC/Render/Texture/AnimatedTexture.c
@@ -15,8 +15,8 @@ AnimatedTexture AnimatedTextureCreate(int textureID)
 
 void AnimatedTextureAnimate(AnimatedTexture texture)
 {
-	if (texture->Type == AnimatedTextureTypeLava) { return LavaTextureAnimate(texture); }
-	if (texture->Type == AnimatedTextureTypeWater) { return WaterTextureAnimate(texture); }
+	if (texture->Type == AnimatedTextureTypeLava) { LavaTextureAnimate(texture); return; }
+	if (texture->Type == AnimatedTextureTypeWater) { WaterTextureAnimate(texture); return; }
 }
 
 void AnimatedTextureDestroy(AnimatedTexture texture)

--- a/MinecraftC/Utilities/List.c
+++ b/MinecraftC/Utilities/List.c
@@ -9,7 +9,7 @@ list(void) ListCreate(unsigned int elementSize)
 	unsigned int * list = malloc(MetaSize + 2 * elementSize);
 	list[0] = elementSize;
 	list[1] = 0;
-	return ((void *)list) + MetaSize;
+	return (unsigned char *)list + MetaSize;
 }
 
 struct ListData
@@ -22,20 +22,20 @@ struct ListData
 static struct ListData ListData(list(void) list)
 {
 	struct ListData data = { 0 };
-	data.ElementSize = *(unsigned int *)(list - MetaSize);
-	data.Count = list - MetaSize / 2;
+	data.ElementSize = *(unsigned int *)((unsigned char *)list - MetaSize);
+	data.Count = (unsigned int *)((unsigned char *)list - MetaSize / 2);
 	data.Capacity = pow(2.0, floor(log2(*data.Count)) + 1.0);
 	return data;
 }
 
 unsigned int ListCount(list(void) list)
 {
-	return *(unsigned int *)(list - MetaSize / 2);
+	return *(unsigned int *)((unsigned char *)list - MetaSize / 2);
 }
 
 unsigned int ListElementSize(list(void) list)
 {
-	return *(unsigned int *)(list - MetaSize);
+	return *(unsigned int *)((unsigned char *)list - MetaSize);
 }
 
 unsigned int ListCapacity(list(void) list)
@@ -55,11 +55,11 @@ list(void) ListInsert(list(void) list, void * element, int index)
 	(*data.Count)++;
 	if (*data.Count == data.Capacity)
 	{
-		list = realloc(list - MetaSize, MetaSize + 2 * data.Capacity * data.ElementSize) + MetaSize;
+		list = (unsigned char *)realloc((unsigned char *)list - MetaSize, MetaSize + 2 * data.Capacity * data.ElementSize) + MetaSize;
 	}
 	data = ListData(list);
-	memmove(list + (index + 1) * data.ElementSize, list + index * data.ElementSize, (*data.Count - 1 - index) * data.ElementSize);
-	memcpy(list + index * data.ElementSize, element, data.ElementSize);
+	memmove((unsigned char *)list + (index + 1) * data.ElementSize, (unsigned char *)list + index * data.ElementSize, (*data.Count - 1 - index) * data.ElementSize);
+	memcpy((unsigned char *)list + index * data.ElementSize, element, data.ElementSize);
 	return list;
 }
 
@@ -79,7 +79,7 @@ list(void) ListRemove(list(void) list, int index)
 	(*data.Count)--;
 	if (*data.Count == data.Capacity / 2 - 1)
 	{
-		list = realloc(list - MetaSize, MetaSize + (data.Capacity / 2) * data.ElementSize) + MetaSize;
+		list = (unsigned char *)realloc((unsigned char *)list - MetaSize, MetaSize + (data.Capacity / 2) * data.ElementSize) + MetaSize;
 	}
 	return list;
 }
@@ -103,7 +103,7 @@ list(void) ListRemoveAll(list(void) list, void * value)
 {
 	for (int i = 0; i < ListCount(list); i++)
 	{
-		if (memcmp(list + i * ListElementSize(list), value, ListElementSize(list)) == 0)
+		if (memcmp((unsigned char *)list + i * ListElementSize(list), value, ListElementSize(list)) == 0)
 		{
 			list = ListRemove(list, i);
 			i--;
@@ -116,7 +116,7 @@ _Bool ListContains(list(void) list, void * value)
 {
 	for (int i = 0; i < ListCount(list); i++)
 	{
-		if (memcmp(list + i * ListElementSize(list), value, ListElementSize(list))) { return true; }
+		if (memcmp((unsigned char *)list + i * ListElementSize(list), value, ListElementSize(list))) { return true; }
 	}
 	return false;
 }
@@ -130,5 +130,5 @@ list(void) ListClear(list(void) list)
 
 void ListDestroy(list(void) list)
 {
-	free(list - MetaSize);
+	free((unsigned char *)list - MetaSize);
 }


### PR DESCRIPTION
First issue:
In many places a void function tries to return the result of another void function which is not allowed. Change these places to call the function and return in the next step.

Second issue:
Some of the list utility functions do a bunch of arithmetic on void pointers which is not allowed. Instead use unsigned char pointers to do the arithmetic.